### PR TITLE
Improved convergence

### DIFF
--- a/PhotoVoltaics/Components/Diodes/Diode.mo
+++ b/PhotoVoltaics/Components/Diodes/Diode.mo
@@ -1,8 +1,9 @@
 within PhotoVoltaics.Components.Diodes;
 model Diode "Diode with one exponential function"
   extends .PhotoVoltaics.Interfaces.PartialDiode;
+  constant Integer MaxExp = 30;
 equation
-  i = Ids * (exp(v / m / Vt) - 1) + v / R;
+  i = Ids * (Functions.exlin(v / m / Vt, MaxExp) - 1) + v / R;
   annotation (
     defaultComponentName = "diode",
     Documentation(info= "<html>

--- a/PhotoVoltaics/Components/Diodes/Diode2Module.mo
+++ b/PhotoVoltaics/Components/Diodes/Diode2Module.mo
@@ -19,12 +19,13 @@ model Diode2Module "Diode model with four different sections including breakthro
   Modelica.Units.SI.Voltage vCell=v/ns/nsModule "Cell voltage";
   Modelica.Units.SI.Voltage vModule=v/nsModule "Module voltage";
   Modelica.Units.SI.Current iModule=i/npModule "Module current";
+  constant Integer MaxExp = 30;
 equation
   // Voltage limit of negative range
   VNeg = m * Vt * log(Vt / VtRef);
   // Current approximation
-  i / npModule = smooth(1, if v / ns / nsModule > VNeg then Ids * (exp(v / ns / nsModule / m / Vt) - 1) + v / ns / nsModule / R elseif v / ns / nsModule > VBv then Ids * v / ns / nsModule / m / VtRef + v / ns / nsModule / R
-   elseif v / ns / nsModule > VNegLin then (-Ibv * exp(-(v / ns / nsModule + Bv) / (Nbv * m * Vt))) + Ids * VBv / m / VtRef + v / ns / nsModule / R else Ids * v / ns / nsModule / m / Vt - Ibv * exp(VRef / m / VtRef) * (1 - (v / ns / nsModule + Bv) / (Nbv * m * Vt) - VRef / m / VtRef) + v / ns / nsModule / R);
+  i / npModule = smooth(1, if v / ns / nsModule > VNeg then Ids * (Functions.exlin(v / ns / nsModule / m / Vt, MaxExp) - 1) + v / ns / nsModule / R elseif v / ns / nsModule > VBv then Ids * v / ns / nsModule / m / VtRef + v / ns / nsModule / R
+   elseif v / ns / nsModule > VNegLin then (-Ibv * Functions.exlin(-(v / ns / nsModule + Bv) / (Nbv * m * Vt), MaxExp)) + Ids * VBv / m / VtRef + v / ns / nsModule / R else Ids * v / ns / nsModule / m / Vt - Ibv * Functions.exlin(VRef / m / VtRef, MaxExp) * (1 - (v / ns / nsModule + Bv) / (Nbv * m * Vt) - VRef / m / VtRef) + v / ns / nsModule / R);
   annotation (
     defaultComponentName = "diode",
     Documentation(info="<html>

--- a/PhotoVoltaics/Examples/SimpleModuleShadow.mo
+++ b/PhotoVoltaics/Examples/SimpleModuleShadow.mo
@@ -34,5 +34,5 @@ equation
     Icon(coordinateSystem(extent = {{-100, -100}, {100, 100}}, preserveAspectRatio = true, initialScale = 0.1, grid = {2, 2})),
     Diagram(coordinateSystem(initialScale = 0.1)),
     experiment(StartTime = 0, StopTime = 1, Tolerance = 1e-06, Interval = 0.0001),
-    __OpenModelica_simulationFlags(jacobian = "coloredNumerical", nls = "newton", s = "dassl", lv = "LOG_STATS"));
+    __OpenModelica_simulationFlags(s = "dassl", lv = "LOG_STATS", jacobian = "coloredNumerical", nls = "newton", nlssMaxDensity = "0", variableFilter = ".*"));
 end SimpleModuleShadow;

--- a/PhotoVoltaics/Functions/exlin.mo
+++ b/PhotoVoltaics/Functions/exlin.mo
@@ -1,0 +1,10 @@
+within PhotoVoltaics.Functions;
+
+function exlin "Exponential function linearly continued for x > Maxexp"
+  extends Modelica.Icons.Function;
+  input Real x;
+  input Real Maxexp;
+  output Real z;
+algorithm
+  z := if x > Maxexp then exp(Maxexp)*(1 + x - Maxexp) else exp(x);
+end exlin;

--- a/PhotoVoltaics/Functions/package.order
+++ b/PhotoVoltaics/Functions/package.order
@@ -2,3 +2,4 @@ limit
 degree
 rad
 dayOfTheYear
+exlin


### PR DESCRIPTION
Hi @christiankral,

I used your library to simulate a Global MPPT-Tracker.
Under partial shading conditions, I often ran into convergence issues, which eventually
lead to a crash of the simulation executable.

As a workaround, I discovered the `exlin(x, maxExp)`-function, that is used for some semiconductors
in the Modelica Standard Library. In my case, the `exlin()` lead to a more stable simulation with
the cost of small inaccuracies of the open circuit voltage.

I further fixed the simulation flags for the shadow-example.

What do you think? 

Regards,
Philipp